### PR TITLE
Отрефакторили структуру Orders. Вместо полей patient_id и service_id …

### DIFF
--- a/internal/models/order.go
+++ b/internal/models/order.go
@@ -2,10 +2,18 @@ package models
 
 import "time"
 
+// type Order struct {
+// 	ID        uint64    `json:"id" db:"id"`
+// 	CreatedAt time.Time `json:"created_at" db:"created_at"`
+// 	PatientID uint64    `json:"patient_id" db:"patient_id"`
+// 	ServiceID []uint64  `json:"service_id" db:"service_id"`
+// 	IsActive  int8      `json:"is_active" db:"is_active"`
+// }
+
 type Order struct {
 	ID        uint64    `json:"id" db:"id"`
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
-	PatientID uint64    `json:"patient_id" db:"patient_id"`
-	ServiceID []uint64  `json:"service_id" db:"service_id"`
+	Patient   Patient   `json:"patient" db:"patient"`
+	Services  []Service `json:"services" db:"services"`
 	IsActive  int8      `json:"is_active" db:"is_active"`
 }

--- a/internal/store/inmemory/inmemory.go
+++ b/internal/store/inmemory/inmemory.go
@@ -31,14 +31,14 @@ func NewInMemoryOrderRepository() *InMemoryOrderRepository {
 }
 
 func (repo *InMemoryOrderRepository) CreateOrder(ctx context.Context, order models.Order) (uint64, error) {
-	patient, err := repo.cliPatients.GetByID(ctx, order.PatientID)
+	patient, err := repo.cliPatients.GetByID(ctx, uint64(order.Patient.ID))
 	if err != nil {
 		return 0, err
 	}
 	fmt.Println("-------------")
 	fmt.Println("    Услуги:")
-	for _, service := range order.ServiceID {
-		svc, err := repo.cliServices.GetByID(ctx, uint64(service))
+	for _, service := range order.Services {
+		svc, err := repo.cliServices.GetByID(ctx, uint64(service.ID))
 		if err != nil {
 			return 0, err
 		}
@@ -87,7 +87,7 @@ func (repo *InMemoryOrderRepository) GetOrdersByPatientID(ctx context.Context, p
 	var orders []models.Order
 	fmt.Printf("InMemory p-id=%d, is-a=%d\n", patient_id, is_active)
 	for _, order := range repo.orders {
-		if order.PatientID != patient_id {
+		if uint64(order.Patient.ID) != patient_id {
 			continue
 		}
 		if is_active == 1 {

--- a/internal/store/pgstore/pgstore.go
+++ b/internal/store/pgstore/pgstore.go
@@ -23,7 +23,7 @@ func (repo *PostgresOrderRepository) CreateOrder(ctx context.Context, order mode
 		INSERT INTO orders (created_at, patient_id, service_id, is_active) 
 		VALUES ($1, $2, $3, $4) 
 		RETURNING id`
-	err := repo.db.QueryRow(ctx, query, order.CreatedAt, order.PatientID, order.ServiceID, order.IsActive).Scan(&id)
+	err := repo.db.QueryRow(ctx, query, order.CreatedAt, order.Patient.ID, order.Services, order.IsActive).Scan(&id)
 	if err != nil {
 		return 0, err
 	}
@@ -37,7 +37,7 @@ func (repo *PostgresOrderRepository) GetOrderByID(ctx context.Context, order_id 
 		FROM orders
 		WHERE id=$1`
 	row := repo.db.QueryRow(ctx, query, order_id)
-	err := row.Scan(&order.ID, &order.CreatedAt, &order.PatientID, &order.ServiceID, &order.IsActive)
+	err := row.Scan(&order.ID, &order.CreatedAt, &order.Patient.ID, &order.Services, &order.IsActive)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (repo *PostgresOrderRepository) GetOrdersByPatientID(ctx context.Context, p
 
 	for rows.Next() {
 		var order models.Order
-		err := rows.Scan(&order.ID, &order.CreatedAt, &order.PatientID, &order.ServiceID, &order.IsActive)
+		err := rows.Scan(&order.ID, &order.CreatedAt, &order.Patient.ID, &order.Services, &order.IsActive)
 		if err != nil {
 			return nil, err
 		}
@@ -99,7 +99,7 @@ func (repo *PostgresOrderRepository) GetAllOrdersList(ctx context.Context, is_ac
 
 	for rows.Next() {
 		var order models.Order
-		err := rows.Scan(&order.ID, &order.CreatedAt, &order.PatientID, &order.ServiceID, &order.IsActive)
+		err := rows.Scan(&order.ID, &order.CreatedAt, &order.Patient.ID, &order.Services, &order.IsActive)
 		if err != nil {
 			return nil, err
 		}
@@ -117,7 +117,7 @@ func (repo *PostgresOrderRepository) UpdateOrder(ctx context.Context, order mode
 		UPDATE orders 
 		SET created_at=$1, patient_id=$2, service_id=$3, is_active=$4 
 		WHERE id=$5`
-	_, err := repo.db.Exec(ctx, query, order.CreatedAt, order.PatientID, order.ServiceID, order.IsActive, order.ID)
+	_, err := repo.db.Exec(ctx, query, order.CreatedAt, order.Patient.ID, order.Services, order.IsActive, order.ID)
 	return err
 }
 


### PR DESCRIPTION
…методом композиции встроили поля patient типа Patient и services типа []Service.

Сделано это для того, что бы можно было отправлять в ответ полную структуру заказа, включая информацию по пациенту и заказанным услугам. В противном случае на стороне запрашивающего требуется отправлять отдельный запрос к сервисам, предоставляющим эту информацию.